### PR TITLE
Use perl -pi instead of sed -i

### DIFF
--- a/src/current/attack/Makefile
+++ b/src/current/attack/Makefile
@@ -9,7 +9,7 @@ all: $(M4)
 	# Strip extra new lines introduced by M4 macros
 	perl -0777pi -e 's/\n{3,}/\n\n/g' $@
 	# Replace "prev_" with "p_" to save space...
-	#sed -i 's/prev_/p_/g' $@
+	#perl -0777pi -e 's/prev_/p_/g' $@
 
 
 clean:

--- a/src/current/lemmas/Makefile
+++ b/src/current/lemmas/Makefile
@@ -13,7 +13,7 @@ clean:
 	# Strip extra new lines introduced by M4 macros
 	perl -0777pi -e 's/\n{3,}/\n\n/g' $@
 	# Replace "prev_" with "p_" to save space...
-	sed -i 's/prev_/p_/g' $@
+	perl -0777pi -e 's/prev_/p_/g' $@
 
 
 proofs:


### PR DESCRIPTION
OSX uses BSD sed by default, for which you need `-i''` for empty-extension inplace writing. GNU sed interprets `-i''` as `-i` with input file `""`, because everything is terrible.

The makefile uses perl anyway so just use that.